### PR TITLE
[EDM-1276] Versioning

### DIFF
--- a/learn-co.gemspec
+++ b/learn-co.gemspec
@@ -16,20 +16,21 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib", "bin"]
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "pry"
 
-  spec.add_runtime_dependency "learn-config", ">= 1.0.77"
-  spec.add_runtime_dependency "learn-generate", ">= 1.0.16"
-  spec.add_runtime_dependency "learn-hello", ">= 1.0.1"
-  spec.add_runtime_dependency "learn-open", "1.2.28"
-  spec.add_runtime_dependency "learn-status", ">= 1.0.1"
-  spec.add_runtime_dependency "learn-submit", "1.3.1"
-  spec.add_runtime_dependency "learn-test", "2.6.1"
-  spec.add_runtime_dependency "learn_linter", ">= 1.6.0"
+  spec.add_runtime_dependency "learn-config", "~> 1"
+  spec.add_runtime_dependency "learn-generate", "~> 1"
+  spec.add_runtime_dependency "learn-hello", "~> 1"
+  spec.add_runtime_dependency "learn-open", "~> 1"
+  spec.add_runtime_dependency "learn-status", "~> 1"
+  spec.add_runtime_dependency "learn-submit", "~> 1"
+  spec.add_runtime_dependency "learn-test", "~> 3"
+  spec.add_runtime_dependency "learn_linter", "~> 1"
+
   spec.add_runtime_dependency "netrc", ">= 0.11.0"
   spec.add_runtime_dependency "thor", ">= 0.19.1"
 end


### PR DESCRIPTION
### Changes

- Update `required_ruby_version` - Could be higher, but playing it safe.
- Update versioning to limit # of times needed to cut parent gem
- Add latest learn-test version


![changes meme](https://media.giphy.com/media/3rgXBGYrye5vSfhMdO/giphy.gif)